### PR TITLE
Fix the reason why pinned values are unsafe

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -48,15 +48,6 @@ pub fn read<T>(ptr: Update<*const T>) -> T;
 pub fn get_unchecked_mut<T>(pin: Pin<&mut T>) -> Update<&mut T>
 // ANCHOR_END: pin-get-unchecked-mut
 
-// ANCHOR: pin-get-unchecked-mut-split
-/// Gets a mutable reference to the pinned data.
-///
-/// # Safety
-///
-/// The data in the result at the end of the borrow has not been moved.
-pub fn get_unchecked_mut<T>(pin: Pin<&mut T>) -> &mut [T .. Update<T>]
-// ANCHOR_END: pin-get-unchecked-mut-split
-
 // ANCHOR: box-into-raw
 /// Consumes a box returning its raw pointer.
 ///

--- a/src/making-it-explicit.md
+++ b/src/making-it-explicit.md
@@ -49,19 +49,11 @@ less safe values, thus providing permissions to use.
 ```
 
 Less common examples are results of unsafe functions. The results are unsafe making the function
-unsafe due to co-variance. And they are unsafe because they have unsafe values (see next paragraph
-for details), thus enforcing restrictions to use.
+unsafe due to co-variance. And they are unsafe because they have unsafe values, thus enforcing
+restrictions to use.
 
 ```rust
 {{#include code.rs:pin-get-unchecked-mut}}
-```
-
-The result in this last example is unsafe because the final value of the mutable reference is robust
-and contra-variant. We can rewrite that same example with the version of mutable references that
-distinguishes between the owned type and the type to return to the lender at the end of the borrow.
-
-```rust
-{{#include code.rs:pin-get-unchecked-mut-split}}
 ```
 
 ### Robustness documentation

--- a/src/unsafe-functions.md
+++ b/src/unsafe-functions.md
@@ -15,8 +15,6 @@ would translate to (preserving any safety documentation):
 ```rust
 fn read<T>(ptr: Update<*const T>) -> T;
 fn get_unchecked_mut<T>(pin: Pin<&mut T>) -> Update<&mut T>
-// or with the unfolded mutable reference notation:
-fn get_unchecked_mut<T>(pin: Pin<&mut T>) -> &mut [T .. Update<T>]
 ```
 
 It is also possible that the predicate isn't about a single type, in which case it may be more

--- a/src/what-is-unsafe.md
+++ b/src/what-is-unsafe.md
@@ -56,9 +56,11 @@ Similarly for the mutable reference type `&mut T`, which I'll write `&mut [T .. 
 the last paragraph of the previous chapter if this is unclear). By contra-variance, it is unsafe if
 `S` is robust. This is the case with the result type of `String::as_mut_vec() -> &mut Vec<u8>` that
 requires permissions to use `S` as UTF-8 (removing the safe values of `Vec<u8>` that are not UTF-8).
-Note also how the restriction on the result type of `Pin::get_unchecked_mut() -> &mut T` is actually
-a permission on its value at the end of the lifetime, such that after the borrow the lender can
-assume the value did not move.
+By co-variance, it is unsafe if `T` is unsafe. This is the case with the result type of
+`Pin::get_unchecked_mut() -> &mut T` that enforces restrictions to use `T` as possibly pinned
+(adding the unsafe values that are safe when under `Pin`). Note that `S` also has restrictions to
+use (the same ones as `T`), thus by contra-variance making the result type and thus the type of
+`Pin::get_unchecked_mut()` robust (remember that types may be both unsafe and robust).
 
 ## Custom types
 


### PR DESCRIPTION
This is related to #2 but doesn't fix it because it doesn't add a full Pin example. Instead it fixes some issues related to Pin.